### PR TITLE
Fix test for missing appmetrics option

### DIFF
--- a/test/test-server-creation.js
+++ b/test/test-server-creation.js
@@ -8,13 +8,6 @@ const util = require('util');
 const appmetrics = require('appmetrics');
 appmetrics.start();
 
-tap.test('throw with no appmetrics', function(t) {
-  t.throws(function() {
-    require('../').monitor({port: '8765'});
-  });
-  t.end();
-});
-
 tap.test('throw with no port', function(t) {
   t.throws(function() {
     require('../').monitor({appmetrics: appmetrics});


### PR DESCRIPTION
During PR review, appmetrics was changed to no longer be mandatory as an
option, but the tests were not updated to account for this.

See 32be6020