### PR TITLE
Update README with basic API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,33 @@
-# Node.js Starter Overview
+# appmetrics-dash
 
-The Node.js Starter demonstrates a simple, reusable Node.js web application based on the Express framework.
+## dash = require('appmetrics-dash')
 
-## Run the app locally
+## dash.monitor(options)
 
-1. [Install Node.js][]
-2. Download and extract the starter code from the Bluemix UI
-3. cd into the app directory
-4. Run `npm install` to install the app's dependencies
-5. Run `npm start` to start the app
-6. Access the running app in a browser at http://localhost:6001
+* options.url {String} Path to serve dashboard from. Optional, defaults to
+  `'/appmetrics-dash'`.
+* options.console {Object} Some messages are printed to the console using
+  `console.log()` and `console.error()`. Optional, defaults to the global
+  `console` object.
+* options.server {Object} An instance of a node `http` server to serve the
+  dashboard from. Optional, default is to create a server (see `port` and
+  `host`).
+* options.port {String|Number} Port to listen on if creating a server. Optional,
+  unused if `server` option is used.
+* options.host {String} Host to listen on if creating a server. Optional,
+  unused if `server` option is used.
+* options.appmetrics {Object} An instance of `require('appmetrics')` can be
+  injected if the application wants to use appmetrics, since it is a singleton
+  module and only one can be present in an application. Optional, defaults to
+  the appmetrics dependency of this module.
+* options.node-report {Object} An instance of `require('node-report')` can be
+  injected if the application wants to use node-report, since it is a singleton
+  module and only one can be present in an application. Optional, defaults to
+  the node-report dependency of this module.
 
-[Install Node.js]: https://nodejs.org/en/download/
+## dash.attach(options)
+
+* options {Object} Options are the same as for `dash.monitor()`.
+
+Auto-attach to all `http` servers, calling `dash.monitor(options)` for every
+server created.


### PR DESCRIPTION
tests are failing because of #15 

API docs are technically wrong (they are missing the authentication options), but that won't matter as soon as #11 lands