### PR TITLE
Fix gcChart's infinite loop in data truncation

### DIFF
--- a/public/js/gcChart.js
+++ b/public/js/gcChart.js
@@ -219,7 +219,7 @@ function updateGCData() {
         var d0 = gcData[0]
         while (d0.hasOwnProperty('time') && d0.time + maxTimeWindow < currentTime) {
             gcData.shift()
-            d = gcData[0]
+            d0 = gcData[0]
         }
 
         // Scale the X range to the new data time interval


### PR DESCRIPTION
Bad variable naming caused an infinite loop when truncating data - fixed by correctly naming variable.