### PR TITLE
add Apache License 2.0 LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,17 @@
+Copyright (c) IBM Corp. 2015,2017. All Rights Reserved.
+Node module: appmetrics-dash
+
+--------
+Copyright 2015,2017 IBM Corp.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/package.json
+++ b/package.json
@@ -36,5 +36,5 @@
     "type": "git",
     "url": "https://github.com/RuntimeTools/appmetrics-dash.git"
   },
-   "license": "Apache-2.0"
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
The project is already under this license, this simply adds a LICENSE
file for it so that it is easier for scanners to detect the license.

Closes #36