### PR TITLE
Fix bug in doclink and change default title

### DIFF
--- a/lib/appmetrics-dash.js
+++ b/lib/appmetrics-dash.js
@@ -71,7 +71,7 @@ exports.monitor = function(options) {
   options = util._extend({}, options);
 
   var url = options.url || '/appmetrics-dash';
-  var title = options.title || 'Application Metrics for Node.js Dashboard';
+  var title = options.title || 'Application Metrics for Node.js';
   var docs = options.docs || 'http://github.com/RuntimeTools/appmetrics-dash';
   options.console = options.console || console;
   var log = options.console.log;

--- a/public/js/header.js
+++ b/public/js/header.js
@@ -18,7 +18,12 @@ socket.on('title', function (data){
     var titleAndDocs = JSON.parse(data);
     if(titleAndDocs.hasOwnProperty('title'))
         d3.select('.leftHeader').text(titleAndDocs.title)
-    if(titleAndDocs.hasOwnProperty('docs'))
-        d3.select('.rightHeader').append("a").attr("href", titleAndDocs.docs).text("Go To Documentation");
+    if(titleAndDocs.hasOwnProperty('docs')) {
+        d3.select('.rightHeader').select('.docLink').remove();
+        d3.select('.rightHeader').append('a')
+            .attr('class', 'docLink')
+            .attr('href', titleAndDocs.docs)
+            .text('Go To Documentation');
+    }
 });
 


### PR DESCRIPTION
"Go To Documentation" could be displayed twice if the server restarted and the dashboard page was left open.