### PR TITLE
Auto-injection with HTTP should not recurse

### DIFF
--- a/lib/appmetrics-dash.js
+++ b/lib/appmetrics-dash.js
@@ -119,12 +119,18 @@ exports.monitor = function(options) {
     server = options.server;
     // XXX(sam) specify a path, to not collide with user's socket.io. Not
     // changing now, it will need coordination with FE javascript.
-    io = require('socket.io')(server);
     debug('patch existing request listeners');
     server.listeners('request').forEach(patch);
+
+    // Don't patch socket.io, it already knows to ignore requests that are not
+    // its own.
+    debug('listen for socket.io');
+    io = require('socket.io')(server);
+
     debug('patch new request listeners...');
     server.on('newListener', function(eventName, listener) {
       if (eventName !== 'request') return;
+      if (listener.__dashboard_patched) return;
       process.nextTick(function() { patch(listener); });
     });
   };
@@ -141,6 +147,7 @@ exports.monitor = function(options) {
     app.use(function(req, res) {
       listener.call(server, req, res);
     });
+    app.__dashboard_patched = true;
     server.on('request', app);
   }
 

--- a/test/test-http-inject-recursion.js
+++ b/test/test-http-inject-recursion.js
@@ -1,0 +1,57 @@
+'use strict';
+
+// Test framework.
+const debug = require('debug')('appmetrics-dash:test');
+const request = require('request');
+const tap = require('tap');
+const util = require('util');
+
+// Setup appmetrics and start app somewhat as a supervisor would.
+const appmetrics = require('appmetrics');
+appmetrics.start();
+require('../').attach({appmetrics: appmetrics});
+
+// Simple http app that triggered .use() recursion
+const server = require('http').createServer();
+
+server.listen(0, 'localhost', function() {
+  const a = this.address();
+  console.log('listening on %s:%s', a.address, a.port);
+});
+
+server.on('request', function(req, res) {
+  res.write('This is the app!');
+  res.end();
+});
+
+let base;
+
+tap.test('start', function(t) {
+  server.on('listening', function() {
+    const port = this.address().port;
+    let addr = this.address().address;
+    if (addr === '0.0.0.0')
+      addr = '127.0.0.1';
+    if (addr === '::')
+      addr = '[::1]';
+    base = util.format('http://%s:%s', addr, port);
+    t.pass('listened');
+    t.end();
+  });
+});
+
+tap.test('dashboard available', function(t) {
+  const options = {
+    url: base + '/appmetrics-dash',
+  };
+  debug('request %j', options);
+  request(options, function(err, resp, body) {
+    t.ifError(err);
+    t.similar(body, /DOCTYPE html/);
+    t.end();
+  });
+});
+
+tap.test('stop', function(t) {
+  server.close(t.end);
+});


### PR DESCRIPTION
In the process of doing #44 , I found a recursion bug for some call patterns. This fixes, and adds a regression test.