### PR TITLE
Update express-basic-auth dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "appmetrics": "^2.0.0",
     "debug": "^2.6.0",
     "express": "^4.14.1",
-    "express-basic-auth": "^0.2.3",
+    "express-basic-auth": "^1.0.0",
     "socket.io": "^1.7.2"
   },
   "optionalDependencies": {


### PR DESCRIPTION
I noticed that you are using an old version of `express-basic-auth`. Version 1.0.0 is fully compatible with the one you are using now, so using it will enable you to get the latest updates, features and bugfixes without having to change any code.