### PR TITLE
Require appmetrics early so we get http data on attach

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,30 @@ var server = app.listen(appEnv.port, '0.0.0.0', function() {
 
 * options {Object} Options are the same as for `dash.monitor()`.
 
-Auto-attach to all `http` servers, calling `dash.monitor(options)` for every
-server created.
+Auto-attach to all `http` servers created after this call, calling `dash.monitor(options)` for every server.
+
+Simple example using attach
+
+    var dash = require('appmetrics-dash');
+    dash.attach();
+
+    var http = require('http');
+
+    const port = 3000;
+
+    const requestHandler = (request, response) => {  
+      response.end('Hello')
+    }
+
+    const server = http.createServer(requestHandler);
+
+    server.listen(port, (err) => {  
+      if (err) {
+        return console.log('An error occurred', err)
+      }
+      console.log(`Server is listening on ${port}`)
+    });
+
 
 ### License
 The Node Application Metrics Dashboard is licensed using an Apache v2.0 License.

--- a/lib/appmetrics-dash.js
+++ b/lib/appmetrics-dash.js
@@ -90,7 +90,7 @@ exports.monitor = function(options) {
   var log = options.console.log;
   var error = options.console.error;
 
-   // appmetrics is a global singleton, allow the user's appmetrics to be
+  // appmetrics is a global singleton, allow the user's appmetrics to be
   // injected, only using our own if the user did not supply one.
   var appmetrics = options.appmetrics || require('appmetrics');
   // XXX(sam) We should let the user turn monitoring on or off! But we need

--- a/lib/appmetrics-dash.js
+++ b/lib/appmetrics-dash.js
@@ -51,7 +51,7 @@ exports.attach = function(options) {
   // here so we get http probe data
   if (!options.appmetrics) {
     options.appmetrics = require('appmetrics');
-  } 
+  }
 
   patch(save.http, require('http'));
   patch(save.https, require('https'));

--- a/lib/appmetrics-dash.js
+++ b/lib/appmetrics-dash.js
@@ -47,6 +47,12 @@ exports.attach = function(options) {
   // Protect our options from modification.
   options = util._extend({}, options);
 
+  // if the user hasn't supplied appmetrics, require
+  // here so we get http probe data
+  if (!options.appmetrics) {
+    options.appmetrics = require('appmetrics');
+  } 
+
   patch(save.http, require('http'));
   patch(save.https, require('https'));
 
@@ -84,7 +90,7 @@ exports.monitor = function(options) {
   var log = options.console.log;
   var error = options.console.error;
 
-  // appmetrics is a global singleton, allow the user's appmetrics to be
+   // appmetrics is a global singleton, allow the user's appmetrics to be
   // injected, only using our own if the user did not supply one.
   var appmetrics = options.appmetrics || require('appmetrics');
   // XXX(sam) We should let the user turn monitoring on or off! But we need


### PR DESCRIPTION
I've updated the attach function to require appmetrics if the user hasn't supplied it.  Also added a simple example so this is clear in the docs.  Fixes issue #63 