### PR TITLE
Ignore snyk false-positive on debug+ms

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,9 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.7.1
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  'npm:ms:20170412':
+    - '*':
+        reason: not exploitable
+        expires: 2017-12-31T00:00:00.000Z
+patch: {}


### PR DESCRIPTION
debug doesn't call the affected code path in ms that uses a Regex, so
isn't vulnerable to the Regex DoS.