### PR TITLE
deps: update socket.io to 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "debug": "^2.6.0",
     "express": "^4.14.1",
     "express-basic-auth": "^1.0.1",
-    "socket.io": "^1.7.2"
+    "socket.io": "^2.0.3"
   },
   "optionalDependencies": {
     "node-report": "^2.1.0"


### PR DESCRIPTION
This addresses a number of the snyk vulnerability warnings, remaining
will be fixed when https://github.com/socketio/socket.io-adapter/pull/52
and https://github.com/socketio/socket.io-emitter/pull/61 are published.