### PR TITLE
Re-send static data when the client confirms it's connected

### DIFF
--- a/lib/appmetrics-dash.js
+++ b/lib/appmetrics-dash.js
@@ -180,7 +180,7 @@ exports.monitor = function(options) {
    */
   io.on('connection', function(socket) {
     var env = monitoring.getEnvironment();
-    var result = [];
+    var envData = [];
     var json;
     for (var entry in env) {
       switch (entry) {
@@ -188,33 +188,43 @@ exports.monitor = function(options) {
           json = {};
           json['Parameter'] = 'Command Line';
           json['Value'] = env[entry];
-          result.push(json);
+          envData.push(json);
           break;
         case 'environment.HOSTNAME':
           json = {};
           json['Parameter'] = 'Hostname';
           json['Value'] = env[entry];
-          result.push(json);
+          envData.push(json);
           break;
         case 'os.arch':
           json = {};
           json['Parameter'] = 'OS Architecture';
           json['Value'] = env[entry];
-          result.push(json);
+          envData.push(json);
           break;
         case 'number.of.processors':
           json = {};
           json['Parameter'] = 'Number of Processors';
           json['Value'] = env[entry];
-          result.push(json);
+          envData.push(json);
           break;
         default:
           break;
       }
     }
-    socket.emit('environment', JSON.stringify(result));
+    // Send static data ASAP but re-send below in case the client isn't ready.
+    socket.emit('environment', JSON.stringify(envData));
     socket.emit('title', JSON.stringify({title: title, docs: docs}));
     socket.emit('status', JSON.stringify({profiling_enabled: profiling_enabled}));
+
+    // When the client confirms it's connected and has listeners ready,
+    // re-send the static data.
+    socket.on('connected', () => {
+      socket.emit('environment', JSON.stringify(envData));
+      socket.emit('title', JSON.stringify({title: title, docs: docs}));
+      socket.emit('status', JSON.stringify({profiling_enabled: profiling_enabled}));
+    });
+
     /*
      * Support enabling/disabling profiling data
      */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appmetrics-dash",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Embedded monitoring dashboard for Node.js applications.",
   "main": "index.js",
   "dependencies": {

--- a/public/index.html
+++ b/public/index.html
@@ -219,9 +219,9 @@
     }
   </script>
   <script type="text/javascript" src="graphmetrics/js/header.js"></script>
+  <script type="text/javascript" src="graphmetrics/js/nodeReport.js"></script>
 
   <!--
-<script type="text/javascript" src="graphmetrics/js/nodeReport.js"></script>
 <script type="text/javascript" src="graphmetrics/js/envTable.js"></script>
 <script type="text/javascript" src="graphmetrics/js/cpuChart.js"></script>
 


### PR DESCRIPTION
Use the "connected" message to re-send static data when the client confirms it's connected to avoid timing issues.
This fixes an issue with the environment page, profiling enablement and title that caused them to sometimes fail to be set.
This also resolves an issue with being unable to see generated node-report files or heap dumps.