### PR TITLE
Remove unnecessary .snyk file

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,9 +1,0 @@
-# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.7.1
-# ignores vulnerabilities until expiry date; change duration by modifying expiry date
-ignore:
-  'npm:ms:20170412':
-    - '*':
-        reason: not exploitable
-        expires: 2017-12-31T00:00:00.000Z
-patch: {}


### PR DESCRIPTION
With dependency updates, there is no longer any dependencies on the `ms` version that was triggering warnings.