### PR TITLE
Resize fix

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -237,7 +237,7 @@
         resizeEnvTable();
         resizeProbesChart();
       } else {
-        resizeFlameGraph();
+        refreshFlameGraph();
       }
     }
   </script>


### PR DESCRIPTION
This just triggers a full refresh when a resize occurs since we need to recalculate the positions of all the rectangles on the flame graph not just resize the canvas it's drawn on.