### PR TITLE
Update appmetrics-dashby.js

### DIFF
--- a/lib/appmetrics-dash.js
+++ b/lib/appmetrics-dash.js
@@ -86,6 +86,7 @@ exports.monitor = function(options) {
 
   var url = options.url || '/appmetrics-dash';
   var title = options.title || 'Application Metrics for Node.js';
+  var demo = options.demo || false;
   var docs = options.docs || 'https://developer.ibm.com/node/application-metrics-node-js/';
 
   options.console = options.console || console;
@@ -215,6 +216,7 @@ exports.monitor = function(options) {
     // Send static data ASAP but re-send below in case the client isn't ready.
     socket.emit('environment', JSON.stringify(envData));
     socket.emit('title', JSON.stringify({title: title, docs: docs}));
+    socket.emit('demo', JSON.stringify({demo: demo}));
     socket.emit('status', JSON.stringify({profiling_enabled: profiling_enabled}));
 
     // When the client confirms it's connected and has listeners ready,
@@ -222,6 +224,7 @@ exports.monitor = function(options) {
     socket.on('connected', () => {
       socket.emit('environment', JSON.stringify(envData));
       socket.emit('title', JSON.stringify({title: title, docs: docs}));
+      socket.emit('demo', JSON.stringify({demo: demo}));
       socket.emit('status', JSON.stringify({profiling_enabled: profiling_enabled}));
     });
 


### PR DESCRIPTION
Adding functionality to suppress "menu" for a "demo" mode.  This will allow "pre-sales" to show dashboard in a publicly available app without worry about users starting heap dumps or profiles