### PR TITLE
Add graph for loop metrics

### DIFF
--- a/lib/appmetrics-dash.js
+++ b/lib/appmetrics-dash.js
@@ -23,7 +23,6 @@ const util = require('util');
 var latestCPUEvent;
 var latestMemEvent;
 var latestGCEvent;
-var latestEventLoopEvent;
 var latestLoopEvent;
 var aggregateHttpEvent;
 var aggregateHttpOutboundEvent;
@@ -282,10 +281,6 @@ exports.monitor = function(options) {
     io.emit('profiling', JSON.stringify(data));
   });
 
-  monitoring.on('eventloop', function(data) {
-    latestEventLoopEvent = data;
-  });
-
   monitoring.on('loop', function(data) {
     latestLoopEvent = data;
   });
@@ -395,10 +390,6 @@ function emitData() {
   if (latestMemEvent) {
     io.emit('memory', JSON.stringify(latestMemEvent));
     latestMemEvent = null;
-  }
-  if (latestEventLoopEvent) {
-    io.emit('eventloop', JSON.stringify(latestEventLoopEvent));
-    latestEventLoopEvent = null;
   }
   if (latestLoopEvent) {
     io.emit('loop', JSON.stringify(latestLoopEvent));

--- a/lib/appmetrics-dash.js
+++ b/lib/appmetrics-dash.js
@@ -24,6 +24,7 @@ var latestCPUEvent;
 var latestMemEvent;
 var latestGCEvent;
 var latestEventLoopEvent;
+var latestLoopEvent;
 var aggregateHttpEvent;
 var aggregateHttpOutboundEvent;
 var aggregateProbeEvents = [];
@@ -285,6 +286,10 @@ exports.monitor = function(options) {
     latestEventLoopEvent = data;
   });
 
+  monitoring.on('loop', function(data) {
+    latestLoopEvent = data;
+  });
+
   monitoring.on('http', function(data) {
     if (!aggregateHttpEvent) {
       aggregateHttpEvent = {};
@@ -394,6 +399,10 @@ function emitData() {
   if (latestEventLoopEvent) {
     io.emit('eventloop', JSON.stringify(latestEventLoopEvent));
     latestEventLoopEvent = null;
+  }
+  if (latestLoopEvent) {
+    io.emit('loop', JSON.stringify(latestLoopEvent));
+    latestLoopEvent = null;
   }
   if (aggregateHttpEvent) {
     io.emit('http', JSON.stringify(aggregateHttpEvent));

--- a/public/index.html
+++ b/public/index.html
@@ -90,6 +90,7 @@
             <div class="col-md-2 hideable" id="memDiv1"></div>
             <div class="col-md-2 hideable" id="gcDiv"></div>
             <div class="col-md-3 hideable" id="eventLoopDiv"></div>
+            <div class="col-md-3 hideable" id="loopDiv"></div>
             <div class="col-md-3 hideable" id="envDiv"></div>
           </div>
           <div class="row">
@@ -172,6 +173,7 @@
   <script type="text/javascript" src="graphmetrics/js/memChart.js"></script>
   <script type="text/javascript" src="graphmetrics/js/gcChart.js"></script>
   <script type="text/javascript" src="graphmetrics/js/eventLoopChart.js"></script>
+  <script type="text/javascript" src="graphmetrics/js/loopChart.js"></script>
   <script type="text/javascript" src="graphmetrics/js/probeEventsChart.js"></script>
   <script type="text/javascript" src="graphmetrics/js/flamegraph.js"></script>
   <script type="text/javascript" src="profiling.js"></script>
@@ -186,6 +188,9 @@
     });
     socket.on('eventloop', function(data) {
       updateEventLoopData(data);
+    });
+    socket.on('loop', function(data) {
+      updateLoopData(data);
     });
     socket.on('gc', function(data) {
       updateGCData(data);
@@ -231,6 +236,7 @@
         resizeHttpOBChart();
         resizeGCChart();
         resizeEventLoopChart();
+        resizeLoopChart();
         resizeHttpThroughputChart();
         resizeHttpTop5Chart();
         resizeMemChart();

--- a/public/index.html
+++ b/public/index.html
@@ -89,7 +89,6 @@
             <div class="col-md-2 hideable" id="cpuDiv1"></div>
             <div class="col-md-2 hideable" id="memDiv1"></div>
             <div class="col-md-2 hideable" id="gcDiv"></div>
-            <div class="col-md-3 hideable" id="eventLoopDiv"></div>
             <div class="col-md-3 hideable" id="loopDiv"></div>
             <div class="col-md-3 hideable" id="envDiv"></div>
           </div>
@@ -172,7 +171,6 @@
 
   <script type="text/javascript" src="graphmetrics/js/memChart.js"></script>
   <script type="text/javascript" src="graphmetrics/js/gcChart.js"></script>
-  <script type="text/javascript" src="graphmetrics/js/eventLoopChart.js"></script>
   <script type="text/javascript" src="graphmetrics/js/loopChart.js"></script>
   <script type="text/javascript" src="graphmetrics/js/probeEventsChart.js"></script>
   <script type="text/javascript" src="graphmetrics/js/flamegraph.js"></script>
@@ -185,9 +183,6 @@
     });
     socket.on('environment', function(data) {
       populateEnvTable(data);
-    });
-    socket.on('eventloop', function(data) {
-      updateEventLoopData(data);
     });
     socket.on('loop', function(data) {
       updateLoopData(data);
@@ -235,7 +230,6 @@
         resizeHttpChart();
         resizeHttpOBChart();
         resizeGCChart();
-        resizeEventLoopChart();
         resizeLoopChart();
         resizeHttpThroughputChart();
         resizeHttpTop5Chart();

--- a/test/ex-badly-behaved.js
+++ b/test/ex-badly-behaved.js
@@ -1,0 +1,36 @@
+'use strict';
+
+require('../').monitor({
+  port: 'PORT' in process.env ? process.env.PORT : 3000,
+  host: 'localhost',
+  appmetrics: require('appmetrics'),
+});
+
+setInterval(function() {
+  if (Math.random() < 0.9) return;
+
+  var start = Date.now();
+  while ((Date.now() - start) < (Math.random() * 100))
+    ;
+}, 1000);
+
+var waiting = 0;
+
+function want() {
+  // randomly choose how much load
+  return Math.random() *
+    (3 * parseInt(process.env.UV_THREADPOOL_SIZE || 4, 10));
+}
+
+function load() {
+  var w = want();
+  while (waiting < w) {
+    waiting++;
+    require('crypto').pbkdf2('pass', 'salt', 102400, 20, 'sha512', function() {
+      waiting--;
+      setImmediate(load);
+    });
+  }
+}
+
+load();


### PR DESCRIPTION
Depends on https://github.com/RuntimeTools/graphmetrics/pull/23 

Works much better with https://github.com/RuntimeTools/appmetrics/pull/467, because without it values are truncated to integral milliseconds,  infrequently reported, and include epoll block times along with execution times.