### PR TITLE
Filter the dashboard from the top 5 http response times.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -143,8 +143,12 @@
       tallerGraphHeight = canvasHeight - margin.top - margin.shortBottom,
       graphHeight = canvasHeight - margin.top - margin.bottom;
 
-    let myurl = location.host;
-    var socket = io.connect(myurl);
+    let hostname = location.host;
+    let pathname = location.pathname
+    // User may have requested appmetrics-dash/index.html
+    let dashboardRoot = "/" + pathname.split('/')[1];
+
+    var socket = io.connect(hostname);
 
     function getTimeFormat() {
       var currentTime = new Date()
@@ -196,6 +200,7 @@
     socket.on('http', function(data) {
       updateHttpData(data);
     });
+    setHttpTop5Options({host: hostname, filteredPath: dashboardRoot});
     socket.on('http-urls', function(data) {
       updateURLData(data);
     });


### PR DESCRIPTION
This change passes the appmetrics-dash path through to graphmetrics so that paths under there can be excluded from the top 5 response times.

This resolves issue #78 