### PR TITLE
Don't hardcode socket.io to the root of the path

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -29,7 +29,7 @@
 <body>
   <!--<h1>Application Metrics Dashboard for Node.js</h1>-->
   <!-- load the d3.js library -->
-  <script src="/socket.io/socket.io.js"></script>
+  <script src="socket.io/socket.io.js"></script>
   <script src="graphmetrics/d3/d3.v3.min.js"></script>
   <script src="graphmetrics/jquery/jquery-3.1.1.min.js"></script>
   <script src="graphmetrics/bootstrap-3.3.7-dist/js/bootstrap.min.js"></script>


### PR DESCRIPTION
This is necessary when proxying only part of the path to the node server.

I don't need credit as a contributor. Feel free to re-do this change in a new PR.