### PR TITLE
Update version to 4.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 node_js:
   - "node"
   - "6"
-  - "4"
 env:
   - CXX=g++-4.8
 addons:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appmetrics-dash",
-  "version": "3.5.0",
+  "version": "4.0.0",
   "description": "Embedded monitoring dashboard for Node.js applications.",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Due to a clash between appmetrics-dash and appmetrics-prometheus when trying to move up to appmetrics 4.0.0 on a minor version change I had to unpublish appmetrics-dash 3.5.0. (Lots of dependencies including generated node applications use semver major to define dependencies which meant that appmetrics-dash 3.5.0 would be pulled in automatically and if a project is also using appmetrics-prometheus then two conflicting versions of appmetrics are required).  So we need to do major version releases of appmetrics-dash and appmetrics-prometheus in order to pull in a major version release of appmetrics.