### PR TITLE
adds option to pass middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 node-report*
 heapdump*.heapsnapshot
+.vscode

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -13,3 +13,4 @@ Authors ordered by first contribution:
  - Pete Robbins (https://github.com/robbinspg)
  - Ayush Gupta (https://github.com/7ayushgupta)
  - Gytis Raciukaitis (https://github.com/noxxious)
+ - Vajahath Ahmed (https://github.com/vajahath)

--- a/lib/appmetrics-dash.js
+++ b/lib/appmetrics-dash.js
@@ -53,6 +53,10 @@ var save = {
 
 var middleware;
 
+const defaultMiddleware = function(req, res, next) {
+  return next();
+};
+
 let profiling_enabled = false;
 
 exports.attach = function(options) {
@@ -98,12 +102,8 @@ exports.monitor = function(options) {
   // Protect our options from modification.
   options = util._extend({}, options);
 
-  // set middleware
-  middleware =
-    options.middleware ||
-    function(req, res, next) {
-      return next();
-    };
+  // set middleware and err handler
+  middleware = options.middleware || defaultMiddleware;
 
   var url = options.url || '/appmetrics-dash';
   var title = options.title || 'Application Metrics for Node.js';
@@ -206,7 +206,7 @@ exports.monitor = function(options) {
   }
 
   function siteError(err, req, res, _next) {
-    res.statusCode = 500;
+    res.statusCode = err.statusCode || 500;
     return res.end(err.message);
   }
   /*

--- a/lib/appmetrics-dash.js
+++ b/lib/appmetrics-dash.js
@@ -51,6 +51,8 @@ var save = {
   https: {},
 };
 
+var middleware;
+
 let profiling_enabled = false;
 
 exports.attach = function(options) {
@@ -96,9 +98,18 @@ exports.monitor = function(options) {
   // Protect our options from modification.
   options = util._extend({}, options);
 
+  // set middleware
+  middleware =
+    options.middleware ||
+    function(req, res, next) {
+      return next();
+    };
+
   var url = options.url || '/appmetrics-dash';
   var title = options.title || 'Application Metrics for Node.js';
-  var docs = options.docs || 'https://developer.ibm.com/node/application-metrics-node-js/';
+  var docs =
+    options.docs ||
+    'https://developer.ibm.com/node/application-metrics-node-js/';
 
   options.console = options.console || console;
   var log = options.console.log;
@@ -136,6 +147,8 @@ exports.monitor = function(options) {
     // Specify a path, to not collide with user's socket.io.
     io = require('socket.io')(server, { path: '/appmetrics-dash/socket.io' });
 
+    app.use(middleware);
+
     // Start the API using the created app
     rest.startApi(app);
 
@@ -169,6 +182,8 @@ exports.monitor = function(options) {
     debug('patching %s', listener);
     server.removeListener('request', listener);
     var app = express();
+
+    app.use(middleware);
 
     // Start the API using the created app
     rest.startApi(app);

--- a/test/test-middleware.js
+++ b/test/test-middleware.js
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright 2017 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+'use strict';
+
+// Test framework.
+const request = require('request');
+const tap = require('tap');
+
+var dash = require('../');
+
+dash.attach({
+  middleware: function(req, res, next) {
+    const num1 = +req.query.num1;
+    const num2 = +req.query.num2;
+    const sum = +req.query.sum;
+
+    if (num1 + num2 === sum) {
+      return next();
+    }
+    return next({ statusCode: 400 });
+  }
+});
+
+var http = require('http');
+
+const port = 3000;
+
+const requestHandler = (request, response) => {
+  response.end('Hello');
+};
+
+const server = http.createServer(requestHandler);
+
+server.listen(port, err => {
+  if (err) {
+    return console.log('An error occurred', err);
+  }
+  console.log(`Server is listening on ${port}`);
+});
+
+tap.test('test a passing middleware', function(t) {
+  request('http://localhost:3000/appmetrics-dash?num1=4&num2=5&sum=9', function(
+    err,
+    res
+  ) {
+    if (err) {
+      throw err;
+    }
+    if (res.statusCode >= 400) {
+      throw new Error('expected status code < 400. but got > 400');
+    }
+    t.pass();
+    t.end();
+  });
+});
+
+tap.test('testing a failing middleware', function(t) {
+  request(
+    'http://localhost:3000/appmetrics-dash?num1=4&num2=5&sum=20',
+    function(err, res) {
+      console.log('---------------', res.statusCode);
+      if (err) {
+        throw err;
+      }
+      if (res.statusCode >= 400) {
+        t.pass();
+        t.end();
+        return;
+      }
+      throw new Error('expected status code = 400. but got !== 400');
+    }
+  );
+});
+
+tap.test('stop', function(t) {
+  server.close(t.end);
+});

--- a/test/test-no-middleware.js
+++ b/test/test-no-middleware.js
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright 2017 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+'use strict';
+
+// Test framework.
+const request = require('request');
+const tap = require('tap');
+
+var dash = require('../');
+
+dash.attach(
+  // not setting any middleware
+);
+
+var http = require('http');
+
+const port = 3000;
+
+const requestHandler = (request, response) => {
+  response.end('Hello');
+};
+
+const server = http.createServer(requestHandler);
+
+server.listen(port, err => {
+  if (err) {
+    return console.log('An error occurred', err);
+  }
+  console.log(`Server is listening on ${port}`);
+});
+
+tap.test('test with no middleware', function(t) {
+  request('http://localhost:3000/appmetrics-dash', function(
+    err,
+    res
+  ) {
+    if (err) {
+      throw err;
+    }
+    if (res.statusCode >= 400) {
+      throw new Error('expected status code < 400. but got > 400');
+    }
+    t.pass();
+    t.end();
+  });
+});
+
+tap.test('stop', function(t) {
+  server.close(t.end);
+});


### PR DESCRIPTION
This PR enable users to pass a middleware along with `options` object.

If I want to protect the appmetrics dash, pass a middleware like:

```js
const options = {
  ...
  middleware: (req, res, next)=>{
    // do stuff to protect
    return next()
  }
  ...
}

attach(options);

```