### PR TITLE
Add the method to the summary data in the collections API.

### DIFF
--- a/REST-API.md
+++ b/REST-API.md
@@ -154,11 +154,13 @@ Returns the metrics from the specified collection.
     },
     "httpUrls": [
       {"url": "http://localhost:9080/myApplication/endpoint1",
+        "method": "GET",
         "hits": 3,
         "averageResponseTime": 4.0,
         "longestResponseTime": 4
       },
       {"url": "http://localhost:9080/myApplication/endpoint2",
+        "method": "POST",
         "hits": 7,
         "averageResponseTime": 53.678,
         "longestResponseTime": 232

--- a/lib/classes/collections.js
+++ b/lib/classes/collections.js
@@ -87,7 +87,7 @@ var Collections = class Collections {
     let list = this.collection.httpUrls;
     let placeInList = -1;
     for (let i = 0; i < list.length; i++) {
-      if (list[i].url === data.url) {
+      if (list[i].url === data.url && list[i].method === data.method) {
         placeInList = i;
       }
     }
@@ -100,7 +100,7 @@ var Collections = class Collections {
         urlData.longestResponseTime = data.duration;
       }
     } else {
-      let urlJSON = { url: data.url, hits: 1, averageResponseTime: data.duration, longestResponseTime: data.duration };
+      let urlJSON = { url: data.url, method: data.method, hits: 1, averageResponseTime: data.duration, longestResponseTime: data.duration };
       this.collection.httpUrls.push(urlJSON);
     }
   }


### PR DESCRIPTION
We have added the method to the summary table but not to the output of the REST API.
We need the method in the REST API output for exactly the same reasons.

The PR for the summary table was: https://github.com/RuntimeTools/appmetrics-dash/pull/153