### PR TITLE
Absolute, non-configurable path to socket.io

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -15,3 +15,4 @@ Authors ordered by first contribution:
  - Gytis Raciukaitis (https://github.com/noxxious)
  - Vajahath Ahmed (https://github.com/vajahath)
  - Jonathan Spruce (https://github.com/jonathan-spruce)
+ - Andreas Opferkuch (https://github.com/s-h-a-d-o-w)

--- a/public/index.html
+++ b/public/index.html
@@ -29,7 +29,7 @@
 <body>
   <!--<h1>Application Metrics Dashboard for Node.js</h1>-->
   <!-- load the d3.js library -->
-  <script src="socket.io/socket.io.js"></script>
+  <script src="/appmetrics-dash/socket.io/socket.io.js"></script>
   <script src="graphmetrics/d3/d3.v3.min.js"></script>
   <script src="graphmetrics/jquery/jquery-3.1.1.min.js"></script>
   <script src="graphmetrics/bootstrap-3.3.7-dist/js/bootstrap.min.js"></script>


### PR DESCRIPTION
Before this change, the relative path assumed that index.html is served from `/appmetrics-dash`. Which causes an error if the user specifies a custom path in the dash options.
Since socket.io is always served from `/appmetrics-dash`, we might as well refer to it in a fixed way here.

Fixes #160