### PR TITLE
Fix #140 by using URL prefix passed in as part of options

### DIFF
--- a/lib/appmetrics-dash.js
+++ b/lib/appmetrics-dash.js
@@ -145,7 +145,7 @@ exports.monitor = function(options) {
     var app = express();
     server = require('http').Server(app);
     // Specify a path, to not collide with user's socket.io.
-    io = require('socket.io')(server, { path: '/appmetrics-dash/socket.io' });
+    io = require('socket.io')(server, { path: url + '/socket.io' });
 
     app.use(middleware);
 
@@ -168,7 +168,7 @@ exports.monitor = function(options) {
     // Don't patch socket.io, it already knows to ignore requests that are not
     // its own.
     debug('listen for socket.io');
-    io = require('socket.io')(server, { path: '/appmetrics-dash/socket.io' });
+    io = require('socket.io')(server, { path: url + '/socket.io' });
 
     debug('patch new request listeners...');
     server.on('newListener', function(eventName, listener) {

--- a/public/index.html
+++ b/public/index.html
@@ -29,7 +29,7 @@
 <body>
   <!--<h1>Application Metrics Dashboard for Node.js</h1>-->
   <!-- load the d3.js library -->
-  <script src="/appmetrics-dash/socket.io/socket.io.js"></script>
+  <script src="socket.io/socket.io.js"></script>
   <script src="graphmetrics/d3/d3.v3.min.js"></script>
   <script src="graphmetrics/jquery/jquery-3.1.1.min.js"></script>
   <script src="graphmetrics/bootstrap-3.3.7-dist/js/bootstrap.min.js"></script>
@@ -165,12 +165,10 @@
       tallerGraphHeight = canvasHeight - margin.top - margin.shortBottom,
       graphHeight = canvasHeight - margin.top - margin.bottom;
 
-    let hostname = location.host;
-    let pathname = location.pathname
     // User may have requested appmetrics-dash/index.html
-    let dashboardRoot = "/" + pathname.split('/')[1];
+    let dashboardRoot = location.pathname.split('index.html')[0] || '/';
 
-    var socket = io.connect(hostname, { path: '/appmetrics-dash/socket.io' });
+    var socket = io.connect(location.host, { path: dashboardRoot + 'socket.io' });
 
     function getTimeFormat() {
       var currentTime = new Date()
@@ -206,7 +204,7 @@
   <script>
 
     let summary = {cpu:{}, gc:{}, memoryPools:{}};
-
+    let hostname = location.host.split(':')[0];
     let envTable = new TextTable('#envDiv', '#summary', localizedStrings.envTitle);
     let summaryTable = new TextTable('#summaryDiv', '#summary', localizedStrings.summaryTitle);
     let httpSummary = new HttpSummary('#httpSummaryDiv', '#summary', localizedStrings.httpSummaryTitle);


### PR DESCRIPTION
The current release accepts a `url` option for deploying the dashboard on a custom path, but then uses hard-coded paths for loading the socket.io library and then connecting to the websocket.

This PR makes it work with the default path (`/appmetrics-dash`) and also with a custom path specified by the user.